### PR TITLE
refactor(executor-matchmerger): return exactly top-k results

### DIFF
--- a/match_merger.py
+++ b/match_merger.py
@@ -1,6 +1,7 @@
 __copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
+import numpy as np
 from typing import List, Tuple
 
 from jina import DocumentArray, Executor, requests
@@ -28,9 +29,17 @@ class MatchMerger(Executor):
             self._merge_shard(results, docs, traversal_paths)
         return DocumentArray(list(results.values()))
 
+    def get_mean_score(self, docs):
+        # Any other non-ugly way to get the active metric?
+        metric_name = list(docs[0].scores.keys())[0]
+        return np.mean([doc.scores[metric_name].value for doc in docs])
+
     def _merge_shard(self, results, docs, traversal_paths):
         for doc in docs.traverse_flat(traversal_paths):
             if doc.id in results:
-                results[doc.id].matches.extend(doc.matches)
+                cur_mean = self.get_mean_score(results[doc.id].matches)
+                new_mean = self.get_mean_score(doc.matches)
+                if new_mean > cur_mean:
+                    results[doc.id] = doc
             else:
                 results[doc.id] = doc

--- a/tests/integration/test_match_merger.py
+++ b/tests/integration/test_match_merger.py
@@ -11,7 +11,9 @@ class MockShard(BaseExecutor):
     @requests
     def search(self, docs: DocumentArray, **kwargs):
         for doc in docs:
-            doc.matches.append(Document(tags={'shard_id': self.runtime_args.pea_id}))
+            matched_doc = Document(tags={'shard_id': self.runtime_args.pea_id})
+            matched_doc.scores['cosine'] = self.runtime_args.pea_id
+            doc.matches.append(matched_doc)
 
 
 @pytest.fixture
@@ -27,6 +29,4 @@ def test_match_merger(docs, shards):
         documents = f.search(docs, return_results=True)[0].docs
         assert len(documents) == 2
         for doc in documents:
-            assert {d.tags['shard_id'] for d in doc.matches} == {
-                float(i) for i in range(shards)
-            }
+            assert [d.scores['cosine'].value for d in doc.matches] == [shards - 1]


### PR DESCRIPTION
Fixing issue [#113](https://github.com/jina-ai/executors/issues/113) from the executors repository.

The MatchMerger executor currently sends `top_k * number_of_shards` results. With this change only the results from the shard which has highest mean score will be returned.

Although, not sure if there should be an extra parameter that lets the user decide if they want results from all the shards.